### PR TITLE
Relax version requirements

### DIFF
--- a/administrate-field-color.gemspec
+++ b/administrate-field-color.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |gem|
   gem.files = `git ls-files`.split("\n")
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
-  gem.add_dependency "administrate", ">= 0.2.0.rc1", "< 0.3.0"
+  gem.add_dependency "administrate", ">= 0.2.0.rc1"
   gem.add_dependency "rails", "~> 4.2"
 end

--- a/administrate-field-color.gemspec
+++ b/administrate-field-color.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |gem|
   gem.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   gem.add_dependency "administrate", ">= 0.2.0.rc1"
-  gem.add_dependency "rails", "~> 4.2"
 end

--- a/administrate-field-color.gemspec
+++ b/administrate-field-color.gemspec
@@ -1,10 +1,8 @@
 $:.push File.expand_path("../lib", __FILE__)
 
-require "administrate/field/color"
-
 Gem::Specification.new do |gem|
   gem.name = "administrate-field-color"
-  gem.version = Administrate::Field::Color::VERSION
+  gem.version = "0.0.1"
   gem.authors = ["Dan Barber"]
   gem.email = ["hello@danbarber.me"]
   gem.homepage = "https://github.com/danbee/administrate_field_color"

--- a/lib/administrate/field/color.rb
+++ b/lib/administrate/field/color.rb
@@ -4,8 +4,6 @@ require "rails"
 module Administrate
   module Field
     class Color < Administrate::Field::Base
-      VERSION = "0.0.1"
-
       class Engine < ::Rails::Engine
       end
     end


### PR DESCRIPTION
Thanks for this gem! I know it's not been updated in 2 years but it still works well with the latest version of administrate and Rails 5.x. This PR just removes the version constraints for those (administrate already depends on Rails). Let me know if you'd still like to force it to be updated every time a new version of administrate comes out.